### PR TITLE
Refactor: ColorData

### DIFF
--- a/mentortee/mentortee/ColorData.swift
+++ b/mentortee/mentortee/ColorData.swift
@@ -1,38 +1,4 @@
-//
-//  ColorData.swift
-//  mentortee
-//
-//  Created by Mingwan Choi on 2022/04/07.
-//
-
 import SwiftUI
-
-extension Color {
-    init(hex: String) {
-        let scanner = Scanner(string: hex)
-        _ = scanner.scanString("#")
-        
-        var rgb: UInt64 = 0
-        scanner.scanHexInt64(&rgb)
-        
-        let r = Double((rgb >> 16) & 0xFF) / 255.0
-        let g = Double((rgb >>  8) & 0xFF) / 255.0
-        let b = Double((rgb >>  0) & 0xFF) / 255.0
-        self.init(red: r, green: g, blue: b)
-    }
-}
-
-extension Color {
-    init(hex: UInt, alpha: Double = 1) {
-        self.init(
-            .sRGB,
-            red: Double((hex >> 16) & 0xff) / 255,
-            green: Double((hex >> 08) & 0xff) / 255,
-            blue: Double((hex >> 00) & 0xff) / 255,
-            opacity: alpha
-        )
-    }
-}
 
 extension Color {
     static let primaryColor = Color(hex: "#DC8D6C")
@@ -41,6 +7,19 @@ extension Color {
     static let subDeepGreen = Color(hex: "#53584C")
     static let subLightGreen = Color(hex: "#97A884")
     static let subIvory = Color(hex: "#E6E7D5")
-    static let backgroundColor = Color(hex: "#eeeeee")
+    static let backgroundColor = Color(hex: "#EEEEEE")
     static let inactiveColor = Color(hex: "#999999")
+
+    init(hex: String) {
+        let scanner = Scanner(string: hex)
+        let _ = scanner.scanString("#")
+
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >> 8) & 0xFF) / 255.0
+        let b = Double((rgb >> 0) & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
 }


### PR DESCRIPTION
날아간 지난 커밋에 추가적으로 리팩토링함
- Color extension 3개 -> 1개
- hex code 대문자 통일
- 불필요한 띄어쓰기 삭제
- _ = scanner.scanString("#") 앞에 let 추가